### PR TITLE
FLIN-2981 Rate limit handling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,9 +28,10 @@ jobs:
         with:
           arguments: build
       - name: Upload built artifacts
+        if: success() || failure()
         uses: actions/upload-artifact@v3
         with:
           name: Package
           path: |
-            build/libs
-            build/reports
+            build/libs/
+            build/reports/

--- a/.github/workflows/code-examples.yml
+++ b/.github/workflows/code-examples.yml
@@ -29,8 +29,9 @@ jobs:
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: build --scan example
+          arguments: build example
       - name: Upload built artifacts
+        if: success() || failure()
         uses: actions/upload-artifact@v3
         with:
           name: Package

--- a/.github/workflows/code-examples.yml
+++ b/.github/workflows/code-examples.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: build example
+          arguments: build --scan example
       - name: Upload built artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/code-examples.yml
+++ b/.github/workflows/code-examples.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: build --scan example
+          arguments: build example
       - name: Upload built artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/code-examples.yml
+++ b/.github/workflows/code-examples.yml
@@ -29,11 +29,11 @@ jobs:
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: build example
+          arguments: build --scan example
       - name: Upload built artifacts
         uses: actions/upload-artifact@v3
         with:
           name: Package
           path: |
-            build/libs
-            build/reports
+            build/libs/
+            build/reports/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,9 +33,10 @@ jobs:
         with:
           arguments: build publish -Psign
       - name: Upload built artifacts
+        if: success() || failure()
         uses: actions/upload-artifact@v3
         with:
           name: Package
           path: |
-            build/libs
-            build/reports
+            build/libs/
+            build/reports/

--- a/src/main/java/com/duffel/exception/RateLimitException.java
+++ b/src/main/java/com/duffel/exception/RateLimitException.java
@@ -1,0 +1,24 @@
+package com.duffel.exception;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+/**
+ * HTTP 429 rate limited
+ */
+@EqualsAndHashCode(callSuper = true)
+@Getter
+@Setter
+@ToString(callSuper = true)
+public class RateLimitException extends DuffelException {
+
+    /**
+     * When will the rate limit reset again.
+     */
+    private LocalDateTime rateLimitReset;
+
+}

--- a/src/test/java/com/duffel/example/BookWithCancelForAnyReasonIT.java
+++ b/src/test/java/com/duffel/example/BookWithCancelForAnyReasonIT.java
@@ -7,6 +7,7 @@ import com.duffel.model.request.OrderRequest;
 import com.duffel.model.request.Payment;
 import com.duffel.model.request.ServiceRequest;
 import com.duffel.model.response.*;
+import com.duffel.model.response.order.metadata.CancelForAnyReasonMetadata;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Test;
@@ -31,14 +32,14 @@ public class BookWithCancelForAnyReasonIT {
 
         // Create an offer request
         OfferRequest.Slice slice = new OfferRequest.Slice();
-        slice.setDepartureDate(LocalDate.now().plusDays(60).format(DateTimeFormatter.ISO_DATE));
-        slice.setOrigin("LGW");
-        slice.setDestination("CDG");
+        slice.setDepartureDate(LocalDate.now().plusDays(100).format(DateTimeFormatter.ISO_DATE));
+        slice.setOrigin("LHR");
+        slice.setDestination("FRA");
 
         Passenger passenger = new Passenger();
         passenger.setType(PassengerType.adult);
         passenger.setGivenName("Test");
-        passenger.setFamilyName("User");
+        passenger.setFamilyName("Cancel");
 
         OfferRequest request = new OfferRequest();
         request.setMaxConnections(0);
@@ -60,6 +61,8 @@ public class BookWithCancelForAnyReasonIT {
 
         Service cfar = offer.getAvailableServices().stream().filter(s -> ServiceType.Type.cancel_for_any_reason == s.getServiceType()).findFirst().orElseThrow();
         LOG.info("🧨 Cancel For Any Reason service available with cost {}{}", cfar.getTotalCurrency(), cfar.getTotalAmount());
+        LOG.info("🔐 T&Cs {}", ((CancelForAnyReasonMetadata) cfar.getMetadata()).getTermsAndConditionsUrl());
+        LOG.info("📝 Copy {}", ((CancelForAnyReasonMetadata) cfar.getMetadata()).getMerchantCopy());
 
         BigDecimal newOrderTotalCost = offer.getTotalAmount().add(cfar.getTotalAmount());
         LOG.info("💳 Cost of flight offer plus CFAR is {}{}", offer.getTotalCurrency(), newOrderTotalCost);
@@ -68,7 +71,7 @@ public class BookWithCancelForAnyReasonIT {
         OrderPassenger orderPassenger = new OrderPassenger();
         orderPassenger.setEmail("test@duffel.com");
         orderPassenger.setGivenName("Test");
-        orderPassenger.setFamilyName("User");
+        orderPassenger.setFamilyName("Cancel");
         orderPassenger.setTitle("Ms");
         orderPassenger.setBornOn("1990-01-01");
         orderPassenger.setPassengerType(PassengerType.adult);

--- a/src/test/java/com/duffel/service/ExceptionTest.java
+++ b/src/test/java/com/duffel/service/ExceptionTest.java
@@ -2,6 +2,7 @@ package com.duffel.service;
 
 import com.duffel.DuffelApiClient;
 import com.duffel.exception.DuffelException;
+import com.duffel.exception.RateLimitException;
 import com.duffel.exception.StandardError;
 import com.duffel.exception.ValidationError;
 import com.duffel.model.request.OfferRequest;
@@ -9,6 +10,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.junit.jupiter.MockServerExtension;
+
+import java.time.LocalDateTime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -45,6 +48,25 @@ public class ExceptionTest {
         assertEquals("422", exception.getMeta().getStatus());
         assertEquals("validation_required", exception.getErrors().get(0).getCode());
         assertEquals("/slices", ((ValidationError) exception.getErrors().get(0)).getSource().getPointer());
+
+        mockClient.reset();
+    }
+
+    @Test
+    void rate_limit_error(MockServerClient mockClient) {
+        mockClient.when(request().withMethod("POST"))
+                .respond(response().withStatusCode(429)
+                        .withHeader("ratelimit-limit", "5")
+                        .withHeader("ratelimit-remaining", "0")
+                        .withHeader("ratelimit-reset", "Fri, 10 Feb 2023 13:24:43 GMT")
+                        .withBody(FixtureHelper.readFixture(this.getClass(), "/fixtures/exceptions/429_rate_limit.json")));
+
+        DuffelApiClient client = new DuffelApiClient("testKey", "http://localhost:" + mockClient.getPort());
+
+        RateLimitException exception = assertThrows(RateLimitException.class, () -> client.offerRequestService.post(new OfferRequest()));
+        assertEquals("429", exception.getMeta().getStatus());
+        assertEquals("rate_limit_exceeded", exception.getErrors().get(0).getCode());
+        assertEquals(LocalDateTime.parse("2023-02-10T13:24:43"), exception.getRateLimitReset());
 
         mockClient.reset();
     }

--- a/src/test/resources/fixtures/exceptions/429_rate_limit.json
+++ b/src/test/resources/fixtures/exceptions/429_rate_limit.json
@@ -1,0 +1,15 @@
+{
+  "meta": {
+    "status": 429,
+    "request_id": "F0J5ZCaJVEn580QADT4B"
+  },
+  "errors": [
+    {
+      "type": "rate_limit_error",
+      "title": "Rate limit exceeded",
+      "message": "Too many requests hit the API too quickly. Please retry your request after the time specified in the `ratelimit-reset` header.",
+      "documentation_url": "https://duffel.com/docs/api/overview/errors",
+      "code": "rate_limit_exceeded"
+    }
+  ]
+}


### PR DESCRIPTION
Add support for decoding rate limit error messages, returning a parsed timeline for how soon more requests can be carried out and a specific error for detecting this response.