### PR TITLE
IS-67 response body compression support

### DIFF
--- a/src/main/java/com/duffel/net/ApiClient.java
+++ b/src/main/java/com/duffel/net/ApiClient.java
@@ -132,8 +132,7 @@ public class ApiClient {
         }
 
         String body;
-        String contentEncoding = response.headers().firstValue(CONTENT_ENCODING_HEADER).orElse("");
-        if (GZIP.equals(contentEncoding)) {
+        if (GZIP.equals(response.headers().firstValue(CONTENT_ENCODING_HEADER).orElse(""))) {
             try (GZIPInputStream stream = new GZIPInputStream(response.body())) {
                 body = new String(stream.readAllBytes(), StandardCharsets.UTF_8);
             } catch (IOException e) {

--- a/src/main/java/com/duffel/net/ApiClient.java
+++ b/src/main/java/com/duffel/net/ApiClient.java
@@ -20,6 +20,7 @@ import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
@@ -134,14 +135,14 @@ public class ApiClient {
         String contentEncoding = response.headers().firstValue(CONTENT_ENCODING_HEADER).orElse("");
         if (GZIP.equals(contentEncoding)) {
             try (GZIPInputStream stream = new GZIPInputStream(response.body())) {
-                body = new String(stream.readAllBytes());
+                body = new String(stream.readAllBytes(), StandardCharsets.UTF_8);
             } catch (IOException e) {
                 LOG.error("Failed to decompress response body", e);
                 throw new RuntimeException(e);
             }
         } else {
             try (InputStream stream = response.body()) {
-                body = new String(stream.readAllBytes());
+                body = new String(stream.readAllBytes(), StandardCharsets.UTF_8);
             } catch (IOException e) {
                 LOG.error("Failed to read uncompressed response body", e);
                 throw new RuntimeException(e);

--- a/src/main/java/com/duffel/net/ApiClient.java
+++ b/src/main/java/com/duffel/net/ApiClient.java
@@ -31,6 +31,7 @@ public class ApiClient {
     private final HttpClient HTTP_CLIENT;
 
     private static final String APPLICATION_JSON = "application/json";
+    private static final String GZIP = "gzip";
     private static final String RATE_LIMIT_HEADER = "ratelimit-reset";
     private final Map<String, String> headers;
     private final String baseEndpoint;
@@ -81,6 +82,7 @@ public class ApiClient {
 
     private void addBasicHeaders() {
         headers.put("Accept", APPLICATION_JSON);
+        headers.put("Accept-Encoding", GZIP);
         headers.put("Content-Type", APPLICATION_JSON);
         headers.put("Duffel-Version", DuffelApiClient.API_VERSION);
         headers.put("User-Agent", DuffelApiClient.USER_AGENT);


### PR DESCRIPTION
Closes #67 
Think I'm running into a combo of https://bugs.openjdk.org/browse/JDK-8228970 and https://github.com/mock-server/mockserver/issues/886

Instead, read out as a byte[] and pass into a `GZIPInputStream`