### PR TITLE
add missing IdentityDocument type to OrderPassenger

### DIFF
--- a/src/main/java/com/duffel/model/IdentityDocumentType.java
+++ b/src/main/java/com/duffel/model/IdentityDocumentType.java
@@ -1,0 +1,8 @@
+package com.duffel.model;
+
+public enum IdentityDocumentType {
+    passport,
+    tax_id,
+    known_traveler_number,
+    passenger_redress_number
+}

--- a/src/main/java/com/duffel/model/OrderPassenger.java
+++ b/src/main/java/com/duffel/model/OrderPassenger.java
@@ -49,7 +49,7 @@ public class OrderPassenger {
      * passenger_identity_documents_required is set to true, then an identity document must be provided.
      */
     @JsonProperty("identity_documents")
-    private List<String> identityDocuments;
+    private List<IdentityDocument> identityDocuments;
 
     /**
      * The id of the passenger, returned when the OffersRequest was created
@@ -86,5 +86,37 @@ public class OrderPassenger {
      */
     @JsonProperty("born_on")
     private String bornOn;
+
+    @EqualsAndHashCode
+    @Getter
+    @Setter
+    @ToString
+    public static class IdentityDocument {
+
+        /**
+         * The type of the identity document. Currently, the only supported types are passport, tax_id, known_traveler_number, and passenger_redress_number. The identity document's type supported by the airline can be found in the offer's supported_passenger_identity_document_types.
+         */
+        @JsonProperty("type")
+        private IdentityDocumentType identityDocumentType;
+
+        /**
+         * Must only be provided for passport type. The date on which the identity document expires
+         */
+        @JsonProperty("expires_on")
+        private String expiresOn;
+
+        /**
+         * Must only be provided for passport, known_traveler_number, and passenger_redress_number types. The ISO 3166-1 alpha-2 code of the country that issued this identity document
+         */
+        @JsonProperty("issuing_country_code")
+        private String issuingCountryCode;
+
+        /**
+         * The unique identifier of the identity document. e.g. the passport number.
+         */
+        @JsonProperty("unique_identifier")
+        private String uniqueIdentifier;
+
+    }
 
 }


### PR DESCRIPTION
I've added the missing type for providing identity documents when creating an order, based on the schema in the Duffel API documentation (https://duffel.com/docs/api/v2/orders/create-order#orders-create-an-order-body-parameters-passengers-passengers-identity-documents).

Please review the changes and let me know if any modifications are needed. Thank you!